### PR TITLE
Спринт №25

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,11 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"
+        tools:ignore="ForegroundServicesPolicy" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
 
     <queries>
         <intent>
@@ -46,6 +51,11 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <service
+            android:name=".presentation.player.service.PlayerPlaybackService"
+            android:exported="false"
+            android:foregroundServiceType="mediaPlayback" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/practicum/playlistmaker/di/PresentationModule.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/di/PresentationModule.kt
@@ -1,6 +1,5 @@
 package com.practicum.playlistmaker.di
 
-import android.media.MediaPlayer
 import com.practicum.playlistmaker.domain.interactor.favorite.AddTrackToFavoritesInteractor
 import com.practicum.playlistmaker.domain.interactor.favorite.GetFavoriteTracksInteractor
 import com.practicum.playlistmaker.domain.interactor.favorite.IsFavoriteTrackInteractor
@@ -55,7 +54,6 @@ val presentationModule = module {
     viewModel { (track: TrackUiDto) ->
         PlayerViewModel(
             track = track,
-            mediaPlayer = get(),
             addTrackToFavoritesInteractor = get<AddTrackToFavoritesInteractor>(),
             removeTrackFromFavoritesInteractor = get<RemoveTrackFromFavoritesInteractor>(),
             isFavoriteTrackInteractor = get<IsFavoriteTrackInteractor>(),
@@ -97,6 +95,4 @@ val presentationModule = module {
             removePlaylistInteractor = get<RemovePlaylistInteractor>()
         )
     }
-
-    factory { MediaPlayer() }
 }

--- a/app/src/main/java/com/practicum/playlistmaker/presentation/player/PlayerConstants.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/presentation/player/PlayerConstants.kt
@@ -2,5 +2,5 @@ package com.practicum.playlistmaker.presentation.player
 
 object PlayerConstants {
     const val DELAY_REFRESH_DURATION_TRACK = 300L
-    const val DEFAULT_POSITION_TRACK = "0:00"
+    const val DEFAULT_POSITION_TRACK = "00:00"
 }

--- a/app/src/main/java/com/practicum/playlistmaker/presentation/player/PlayerFragment.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/presentation/player/PlayerFragment.kt
@@ -1,11 +1,23 @@
 package com.practicum.playlistmaker.presentation.player
 
+import android.Manifest
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.ServiceConnection
+import android.content.pm.PackageManager
+import android.net.ConnectivityManager
+import android.os.Build
 import android.os.Bundle
+import android.os.IBinder
 import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
@@ -18,6 +30,8 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.practicum.playlistmaker.R
 import com.practicum.playlistmaker.databinding.FragmentPlayerBinding
 import com.practicum.playlistmaker.presentation.models.TrackUiDto
+import com.practicum.playlistmaker.presentation.player.service.PlayerPlaybackService
+import com.practicum.playlistmaker.util.InternetConnectionReceiver
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
 
@@ -35,6 +49,28 @@ class PlayerFragment : Fragment() {
     private lateinit var bottomSheetBehavior: BottomSheetBehavior<View>
     private val playlistsAdapter = PlaylistBottomSheetAdapter { playlist ->
         viewModel.onAddToPlaylistClicked(playlist)
+    }
+
+    private var isInternetReceiverRegistered = false
+    private val internetReceiver = InternetConnectionReceiver { context ->
+        showNoInternetToast(context)
+    }
+
+    private val notificationPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { _ -> }
+
+    private var isServiceBound = false
+    private val playerServiceConnection = object : ServiceConnection {
+        override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
+            val binder = service as? PlayerPlaybackService.PlayerPlaybackBinder ?: return
+            viewModel.onServiceConnected(binder.getService())
+            isServiceBound = true
+        }
+
+        override fun onServiceDisconnected(name: ComponentName?) {
+            isServiceBound = false
+            viewModel.onServiceDisconnected()
+        }
     }
 
     private val bottomSheetCallback = object : BottomSheetBehavior.BottomSheetCallback() {
@@ -66,6 +102,8 @@ class PlayerFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        requestNotificationPermissionIfNeeded()
+        bindPlayerService()
         bindTrack(track)
         setupBottomSheet()
         setupObservers()
@@ -74,17 +112,30 @@ class PlayerFragment : Fragment() {
 
     override fun onStart() {
         super.onStart()
+        viewModel.onPlayerScreenStarted()
         if (::bottomSheetBehavior.isInitialized) {
             syncBottomSheetOverlay()
         }
     }
 
+    override fun onResume() {
+        super.onResume()
+        internetReceiver.resetInitialState(requireContext())
+        registerInternetReceiver()
+    }
+
     override fun onPause() {
+        unregisterInternetReceiver()
         super.onPause()
-        viewModel.onPause()
+    }
+
+    override fun onStop() {
+        viewModel.onPlayerScreenStopped(canShowNotifications())
+        super.onStop()
     }
 
     override fun onDestroyView() {
+        unbindPlayerService()
         super.onDestroyView()
         if (::bottomSheetBehavior.isInitialized) {
             bottomSheetBehavior.removeBottomSheetCallback(bottomSheetCallback)
@@ -224,5 +275,69 @@ class PlayerFragment : Fragment() {
 
     private fun showToast(message: String) {
         Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show()
+    }
+
+    private fun registerInternetReceiver() {
+        if (isInternetReceiverRegistered) return
+        ContextCompat.registerReceiver(
+            requireContext(),
+            internetReceiver,
+            IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION),
+            ContextCompat.RECEIVER_NOT_EXPORTED
+        )
+        isInternetReceiverRegistered = true
+    }
+
+    private fun unregisterInternetReceiver() {
+        if (!isInternetReceiverRegistered) return
+        try {
+            requireContext().unregisterReceiver(internetReceiver)
+        } catch (_: IllegalArgumentException) {
+        } finally {
+            isInternetReceiverRegistered = false
+        }
+    }
+
+    private fun showNoInternetToast(context: Context) {
+        Toast.makeText(
+            context,
+            context.getString(R.string.no_internet_connection),
+            Toast.LENGTH_SHORT
+        ).show()
+    }
+
+    private fun bindPlayerService() {
+        if (isServiceBound) return
+        val intent = Intent(requireContext(), PlayerPlaybackService::class.java).apply {
+            putExtra(PlayerPlaybackService.EXTRA_PREVIEW_URL, track.previewUrl)
+            putExtra(PlayerPlaybackService.EXTRA_ARTIST_NAME, track.artistName)
+            putExtra(PlayerPlaybackService.EXTRA_TRACK_NAME, track.trackName)
+        }
+        requireContext().bindService(intent, playerServiceConnection, Context.BIND_AUTO_CREATE)
+    }
+
+    private fun unbindPlayerService() {
+        if (!isServiceBound) return
+        try {
+            requireContext().unbindService(playerServiceConnection)
+        } catch (_: IllegalArgumentException) {
+        } finally {
+            isServiceBound = false
+            viewModel.onServiceDisconnected()
+        }
+    }
+
+    private fun canShowNotifications(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return true
+        return ContextCompat.checkSelfPermission(
+            requireContext(),
+            Manifest.permission.POST_NOTIFICATIONS
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun requestNotificationPermissionIfNeeded() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+        if (canShowNotifications()) return
+        notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
     }
 }

--- a/app/src/main/java/com/practicum/playlistmaker/presentation/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/presentation/player/PlayerViewModel.kt
@@ -1,6 +1,5 @@
 package com.practicum.playlistmaker.presentation.player
 
-import android.media.MediaPlayer
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -16,15 +15,14 @@ import com.practicum.playlistmaker.presentation.models.OptionalField
 import com.practicum.playlistmaker.presentation.models.PlayerUiState
 import com.practicum.playlistmaker.presentation.models.PlaylistUiDto
 import com.practicum.playlistmaker.presentation.models.TrackUiDto
+import com.practicum.playlistmaker.presentation.player.service.PlayerPlaybackState
+import com.practicum.playlistmaker.presentation.player.service.PlayerServiceApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 class PlayerViewModel(
     private val track: TrackUiDto,
-    private val mediaPlayer: MediaPlayer,
     private val addTrackToFavoritesInteractor: AddTrackToFavoritesInteractor,
     private val removeTrackFromFavoritesInteractor: RemoveTrackFromFavoritesInteractor,
     private val isFavoriteTrackInteractor: IsFavoriteTrackInteractor,
@@ -47,30 +45,38 @@ class PlayerViewModel(
     private val addToPlaylistState = MutableLiveData<AddToPlaylistUiState?>(null)
     val addToPlaylistResult: LiveData<AddToPlaylistUiState?> = addToPlaylistState
 
-    private var timerJob: Job? = null
+    private var playerService: PlayerServiceApi? = null
+    private var playerStateJob: Job? = null
 
     init {
-        preparePlayer()
         checkFavoriteStatus()
         observePlaylists()
     }
 
     override fun onCleared() {
         super.onCleared()
-        mediaPlayer.release()
-        timerJob?.cancel()
+        playerStateJob?.cancel()
     }
 
     fun onPlayButtonClicked() {
-        when (state.value?.playerState) {
-            PlayerState.Playing -> pausePlayer()
-            PlayerState.Prepared, PlayerState.Paused -> startPlayer()
+        val service = playerService ?: return
+        when (service.getPlayerState()) {
+            PlayerState.Playing -> service.pause()
+            PlayerState.Prepared, PlayerState.Paused -> service.play()
             else -> {}
         }
     }
 
-    fun onPause() {
-        pausePlayer()
+    fun onPlayerScreenStarted() {
+        playerService?.stopForegroundMode()
+    }
+
+    fun onPlayerScreenStopped(canShowNotification: Boolean) {
+        if (!canShowNotification) return
+        val service = playerService ?: return
+        if (service.getPlayerState() == PlayerState.Playing) {
+            service.startForegroundMode()
+        }
     }
 
     fun onFavoriteButtonClicked() {
@@ -135,14 +141,6 @@ class PlayerViewModel(
         state.value = transform(current)
     }
 
-    private fun setPlayerState(state: PlayerState) {
-        updateState { it.copy(playerState = state) }
-    }
-
-    private fun setProgress(progress: String) {
-        updateState { it.copy(progress = progress) }
-    }
-
     fun isoToYear(iso: String?): String? =
         iso?.takeIf { it.length >= 4 }?.substring(0, 4)
 
@@ -159,47 +157,27 @@ class PlayerViewModel(
         )
     }
 
-    private fun preparePlayer() {
-        mediaPlayer.setDataSource(track.previewUrl)
-        mediaPlayer.prepareAsync()
-        mediaPlayer.setOnPreparedListener {
-            setPlayerState(PlayerState.Prepared)
+    fun onServiceConnected(service: PlayerServiceApi) {
+        playerService = service
+        playerStateJob?.cancel()
+        playerStateJob = viewModelScope.launch {
+            service.playbackState().collectLatest(::onPlaybackStateChanged)
         }
-        mediaPlayer.setOnCompletionListener {
-            timerJob?.cancel()
-            mediaPlayer.seekTo(0)
-            updateState {
-                it.copy(
-                    playerState = PlayerState.Prepared,
-                    progress = PlayerConstants.DEFAULT_POSITION_TRACK
-                )
-            }
+        service.stopForegroundMode()
+    }
+
+    fun onServiceDisconnected() {
+        playerStateJob?.cancel()
+        playerStateJob = null
+        playerService = null
+    }
+
+    private fun onPlaybackStateChanged(serviceState: PlayerPlaybackState) {
+        updateState {
+            it.copy(
+                playerState = serviceState.playerState,
+                progress = serviceState.progress
+            )
         }
-    }
-
-    private fun startPlayer() {
-        mediaPlayer.start()
-        setPlayerState(PlayerState.Playing)
-        startTimer()
-    }
-
-    private fun pausePlayer() {
-        mediaPlayer.pause()
-        setPlayerState(PlayerState.Paused)
-        timerJob?.cancel()
-    }
-
-    private fun startTimer() {
-        timerJob?.cancel()
-        timerJob = viewModelScope.launch {
-            while (state.value?.playerState == PlayerState.Playing) {
-                delay(PlayerConstants.DELAY_REFRESH_DURATION_TRACK)
-                setProgress(formatTime(mediaPlayer.currentPosition))
-            }
-        }
-    }
-
-    private fun formatTime(time: Int): String {
-        return SimpleDateFormat("m:ss", Locale.getDefault()).format(time)
     }
 }

--- a/app/src/main/java/com/practicum/playlistmaker/presentation/player/service/PlayerPlaybackService.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/presentation/player/service/PlayerPlaybackService.kt
@@ -1,0 +1,247 @@
+package com.practicum.playlistmaker.presentation.player.service
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.media.MediaPlayer
+import android.os.Binder
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.app.ServiceCompat
+import com.practicum.playlistmaker.R
+import com.practicum.playlistmaker.presentation.player.PlayerConstants
+import com.practicum.playlistmaker.presentation.player.PlayerState
+import com.practicum.playlistmaker.presentation.root.RootActivity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+class PlayerPlaybackService : Service(), PlayerServiceApi {
+
+    inner class PlayerPlaybackBinder : Binder() {
+        fun getService(): PlayerPlaybackService = this@PlayerPlaybackService
+    }
+
+    companion object {
+        const val EXTRA_PREVIEW_URL = "extra_preview_url"
+        const val EXTRA_ARTIST_NAME = "extra_artist_name"
+        const val EXTRA_TRACK_NAME = "extra_track_name"
+
+        private const val NOTIFICATION_CHANNEL_ID = "playlist_maker_playback"
+        private const val NOTIFICATION_ID = 1001
+    }
+
+    private val binder = PlayerPlaybackBinder()
+
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private var timerJob: Job? = null
+
+    private var mediaPlayer: MediaPlayer? = null
+    private var previewUrl: String? = null
+    private var artistName: String = ""
+    private var trackName: String = ""
+
+    private val _state = MutableStateFlow(PlayerPlaybackState())
+    private val state: StateFlow<PlayerPlaybackState> = _state.asStateFlow()
+
+    private var isInForegroundMode = false
+
+    override fun onCreate() {
+        super.onCreate()
+        createNotificationChannel()
+    }
+
+    override fun onBind(intent: Intent?): IBinder {
+        previewUrl = intent?.getStringExtra(EXTRA_PREVIEW_URL)
+        artistName = intent?.getStringExtra(EXTRA_ARTIST_NAME).orEmpty()
+        trackName = intent?.getStringExtra(EXTRA_TRACK_NAME).orEmpty()
+        preparePlayer()
+        return binder
+    }
+
+    override fun onUnbind(intent: Intent?): Boolean {
+        stopForegroundMode()
+        stopAndRelease()
+        stopSelf()
+        return super.onUnbind(intent)
+    }
+
+    override fun onDestroy() {
+        stopForegroundMode()
+        stopAndRelease()
+        serviceScope.coroutineContext.cancel()
+        super.onDestroy()
+    }
+
+    override fun play() {
+        val player = mediaPlayer ?: return
+        if (_state.value.playerState == PlayerState.Default) return
+        if (!player.isPlaying) {
+            player.start()
+        }
+        setPlayerState(PlayerState.Playing)
+        startTimer()
+        if (isInForegroundMode) {
+            updateForegroundNotification()
+        }
+    }
+
+    override fun pause() {
+        val player = mediaPlayer ?: return
+        if (player.isPlaying) {
+            player.pause()
+        }
+        timerJob?.cancel()
+        setPlayerState(PlayerState.Paused)
+        stopForegroundMode()
+    }
+
+    override fun getPlayerState(): PlayerState = _state.value.playerState
+
+    override fun playbackState(): StateFlow<PlayerPlaybackState> = state
+
+    override fun startForegroundMode() {
+        if (isInForegroundMode) return
+        if (_state.value.playerState != PlayerState.Playing) return
+
+        try {
+            isInForegroundMode = true
+            val notification = buildNotification()
+
+            ServiceCompat.startForeground(
+                this,
+                NOTIFICATION_ID,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+            )
+        } catch (_: SecurityException) {
+            isInForegroundMode = false
+        } catch (_: IllegalStateException) {
+            isInForegroundMode = false
+        } catch (_: RuntimeException) {
+            isInForegroundMode = false
+        }
+    }
+
+    override fun stopForegroundMode() {
+        if (!isInForegroundMode) return
+        isInForegroundMode = false
+        ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
+    }
+
+    private fun preparePlayer() {
+        stopAndRelease()
+
+        val url = previewUrl
+        if (url.isNullOrBlank()) {
+            _state.value = PlayerPlaybackState(playerState = PlayerState.Default)
+            return
+        }
+
+        val player = MediaPlayer()
+        mediaPlayer = player
+        _state.value = PlayerPlaybackState(playerState = PlayerState.Default)
+
+        player.setDataSource(url)
+        player.setOnPreparedListener {
+            _state.value = _state.value.copy(playerState = PlayerState.Prepared)
+        }
+        player.setOnCompletionListener {
+            timerJob?.cancel()
+            stopForegroundMode()
+            it.seekTo(0)
+            _state.value = PlayerPlaybackState(
+                playerState = PlayerState.Prepared,
+                progress = PlayerConstants.DEFAULT_POSITION_TRACK
+            )
+        }
+        player.prepareAsync()
+    }
+
+    private fun stopAndRelease() {
+        timerJob?.cancel()
+        timerJob = null
+
+        mediaPlayer?.setOnPreparedListener(null)
+        mediaPlayer?.setOnCompletionListener(null)
+        mediaPlayer?.release()
+        mediaPlayer = null
+
+        _state.value = PlayerPlaybackState(playerState = PlayerState.Default)
+    }
+
+    private fun startTimer() {
+        timerJob?.cancel()
+        timerJob = serviceScope.launch {
+            while (_state.value.playerState == PlayerState.Playing) {
+                delay(PlayerConstants.DELAY_REFRESH_DURATION_TRACK)
+                val progress = mediaPlayer?.currentPosition?.let(::formatTime)
+                    ?: PlayerConstants.DEFAULT_POSITION_TRACK
+                _state.value = _state.value.copy(progress = progress)
+            }
+        }
+    }
+
+    private fun setPlayerState(newState: PlayerState) {
+        _state.value = _state.value.copy(playerState = newState)
+    }
+
+    private fun formatTime(timeMs: Int): String {
+        return SimpleDateFormat("mm:ss", Locale.getDefault()).format(timeMs)
+    }
+
+    private fun createNotificationChannel() {
+        val manager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+        val channel = NotificationChannel(
+            NOTIFICATION_CHANNEL_ID,
+            getString(R.string.app_name),
+            NotificationManager.IMPORTANCE_LOW
+        )
+        manager.createNotificationChannel(channel)
+    }
+
+    private fun buildNotification() = NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
+        .setSmallIcon(R.drawable.ic_media_library24)
+        .setContentTitle(getString(R.string.app_name))
+        .setContentText(notificationText())
+        .setContentIntent(notificationContentIntent())
+        .setOngoing(true)
+        .setOnlyAlertOnce(true)
+        .build()
+
+    private fun updateForegroundNotification() {
+        if (!isInForegroundMode) return
+        try {
+            val manager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+            manager.notify(NOTIFICATION_ID, buildNotification())
+        } catch (_: SecurityException) {
+            stopForegroundMode()
+        }
+    }
+
+    private fun notificationText(): String {
+        val trackText = listOf(artistName, trackName).filter { it.isNotBlank() }.joinToString(" - ")
+        return trackText.ifBlank { getString(R.string.app_name) }
+    }
+
+    private fun notificationContentIntent(): PendingIntent {
+        val intent = Intent(this, RootActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+        val flags = PendingIntent.FLAG_UPDATE_CURRENT or
+                PendingIntent.FLAG_IMMUTABLE
+        return PendingIntent.getActivity(this, 0, intent, flags)
+    }
+}

--- a/app/src/main/java/com/practicum/playlistmaker/presentation/player/service/PlayerPlaybackState.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/presentation/player/service/PlayerPlaybackState.kt
@@ -1,0 +1,10 @@
+package com.practicum.playlistmaker.presentation.player.service
+
+import com.practicum.playlistmaker.presentation.player.PlayerConstants
+import com.practicum.playlistmaker.presentation.player.PlayerState
+
+data class PlayerPlaybackState(
+    val playerState: PlayerState = PlayerState.Default,
+    val progress: String = PlayerConstants.DEFAULT_POSITION_TRACK
+)
+

--- a/app/src/main/java/com/practicum/playlistmaker/presentation/player/service/PlayerServiceApi.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/presentation/player/service/PlayerServiceApi.kt
@@ -1,0 +1,16 @@
+package com.practicum.playlistmaker.presentation.player.service
+
+import com.practicum.playlistmaker.presentation.player.PlayerState
+import kotlinx.coroutines.flow.StateFlow
+
+interface PlayerServiceApi {
+    fun play()
+    fun pause()
+
+    fun getPlayerState(): PlayerState
+    fun playbackState(): StateFlow<PlayerPlaybackState>
+
+    fun startForegroundMode()
+    fun stopForegroundMode()
+}
+

--- a/app/src/main/java/com/practicum/playlistmaker/presentation/player/view/PlaybackButtonView.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/presentation/player/view/PlaybackButtonView.kt
@@ -1,9 +1,11 @@
 package com.practicum.playlistmaker.presentation.player.view
 
+import android.annotation.SuppressLint
 import android.content.Context
-import android.graphics.Bitmap
 import android.graphics.Canvas
+import android.graphics.Rect
 import android.graphics.RectF
+import android.graphics.drawable.Drawable
 import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.View
@@ -12,7 +14,7 @@ import com.practicum.playlistmaker.R
 import androidx.core.content.withStyledAttributes
 import androidx.core.graphics.drawable.DrawableCompat
 import kotlin.math.min
-import androidx.core.graphics.createBitmap
+import kotlin.math.roundToInt
 
 class PlaybackButtonView @JvmOverloads constructor(
     context: Context,
@@ -20,8 +22,8 @@ class PlaybackButtonView @JvmOverloads constructor(
     defStyleAttr: Int = 0
 ) : View(context, attrs, defStyleAttr) {
 
-    private var playBitmap: Bitmap? = null
-    private var pauseBitmap: Bitmap? = null
+    private var playDrawable: Drawable? = null
+    private var pauseDrawable: Drawable? = null
     private var isPlaying = false
     private var tintColor: Int? = null
     private val playRect = RectF()
@@ -45,8 +47,8 @@ class PlaybackButtonView @JvmOverloads constructor(
             )
             tintColor = getColor(R.styleable.PlaybackButtonView_playbackTint, 0)
                 .takeIf { hasValue(R.styleable.PlaybackButtonView_playbackTint) }
-            playBitmap = loadBitmap(playResId)
-            pauseBitmap = loadBitmap(pauseResId)
+            playDrawable = loadDrawable(playResId)
+            pauseDrawable = loadDrawable(pauseResId)
         }
     }
 
@@ -56,12 +58,20 @@ class PlaybackButtonView @JvmOverloads constructor(
         invalidate()
     }
 
+    @SuppressLint("DrawAllocation")
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
-        val bitmap = if (isPlaying) pauseBitmap else playBitmap
+        val drawable = if (isPlaying) pauseDrawable else playDrawable
         val dest = if (isPlaying) pauseRect else playRect
-        if (bitmap == null || dest.isEmpty) return
-        canvas.drawBitmap(bitmap, null, dest, null)
+        if (drawable == null || dest.isEmpty) return
+
+        drawable.bounds = Rect(
+            dest.left.roundToInt(),
+            dest.top.roundToInt(),
+            dest.right.roundToInt(),
+            dest.bottom.roundToInt()
+        )
+        drawable.draw(canvas)
     }
 
     override fun onTouchEvent(event: MotionEvent): Boolean {
@@ -83,9 +93,9 @@ class PlaybackButtonView @JvmOverloads constructor(
     }
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-        val bitmap = playBitmap ?: pauseBitmap
-        val desiredWidth = (bitmap?.width ?: 0) + paddingLeft + paddingRight
-        val desiredHeight = (bitmap?.height ?: 0) + paddingTop + paddingBottom
+        val drawable = playDrawable ?: pauseDrawable
+        val desiredWidth = (drawable?.intrinsicWidth?.takeIf { it > 0 } ?: 0) + paddingLeft + paddingRight
+        val desiredHeight = (drawable?.intrinsicHeight?.takeIf { it > 0 } ?: 0) + paddingTop + paddingBottom
         val measuredWidth = resolveSize(desiredWidth, widthMeasureSpec)
         val measuredHeight = resolveSize(desiredHeight, heightMeasureSpec)
         setMeasuredDimension(measuredWidth, measuredHeight)
@@ -93,8 +103,8 @@ class PlaybackButtonView @JvmOverloads constructor(
 
     override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
         super.onSizeChanged(w, h, oldw, oldh)
-        updateRect(playBitmap, playRect, w, h)
-        updateRect(pauseBitmap, pauseRect, w, h)
+        updateRect(playDrawable, playRect, w, h)
+        updateRect(pauseDrawable, pauseRect, w, h)
     }
 
     private fun toggleState() {
@@ -102,22 +112,16 @@ class PlaybackButtonView @JvmOverloads constructor(
         invalidate()
     }
 
-    private fun loadBitmap(resId: Int): Bitmap? {
+    private fun loadDrawable(resId: Int): Drawable? {
         if (resId == 0) return null
         val drawable = AppCompatResources.getDrawable(context, resId)?.mutate() ?: return null
         val wrapped = DrawableCompat.wrap(drawable)
         tintColor?.let { DrawableCompat.setTint(wrapped, it) }
-        val width = if (drawable.intrinsicWidth > 0) drawable.intrinsicWidth else 1
-        val height = if (drawable.intrinsicHeight > 0) drawable.intrinsicHeight else 1
-        val bitmap = createBitmap(width, height)
-        val canvas = Canvas(bitmap)
-        wrapped.setBounds(0, 0, width, height)
-        wrapped.draw(canvas)
-        return bitmap
+        return wrapped
     }
 
-    private fun updateRect(bitmap: Bitmap?, rect: RectF, width: Int, height: Int) {
-        if (bitmap == null) {
+    private fun updateRect(drawable: Drawable?, rect: RectF, width: Int, height: Int) {
+        if (drawable == null) {
             rect.setEmpty()
             return
         }
@@ -127,12 +131,14 @@ class PlaybackButtonView @JvmOverloads constructor(
             rect.setEmpty()
             return
         }
+        val drawableWidth = drawable.intrinsicWidth.takeIf { it > 0 } ?: 1
+        val drawableHeight = drawable.intrinsicHeight.takeIf { it > 0 } ?: 1
         val scale = min(
-            availableWidth.toFloat() / bitmap.width,
-            availableHeight.toFloat() / bitmap.height
+            availableWidth.toFloat() / drawableWidth,
+            availableHeight.toFloat() / drawableHeight
         )
-        val scaledWidth = bitmap.width * scale
-        val scaledHeight = bitmap.height * scale
+        val scaledWidth = drawableWidth * scale
+        val scaledHeight = drawableHeight * scale
         val left = paddingLeft + (availableWidth - scaledWidth) / 2f
         val top = paddingTop + (availableHeight - scaledHeight) / 2f
         rect.set(left, top, left + scaledWidth, top + scaledHeight)

--- a/app/src/main/java/com/practicum/playlistmaker/presentation/search/SearchFragment.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/presentation/search/SearchFragment.kt
@@ -1,5 +1,8 @@
 package com.practicum.playlistmaker.presentation.search
 
+import android.content.Context
+import android.content.IntentFilter
+import android.net.ConnectivityManager
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
@@ -8,11 +11,15 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
+import android.widget.Toast
+import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
+import com.practicum.playlistmaker.R
 import com.practicum.playlistmaker.databinding.FragmentSearchBinding
 import com.practicum.playlistmaker.presentation.models.TrackUiDto
+import com.practicum.playlistmaker.util.InternetConnectionReceiver
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class SearchFragment : Fragment() {
@@ -24,6 +31,11 @@ class SearchFragment : Fragment() {
 
     private lateinit var searchAdapter: TrackAdapter
     private lateinit var historyAdapter: TrackAdapter
+
+    private var isInternetReceiverRegistered = false
+    private val internetReceiver = InternetConnectionReceiver { context ->
+        showNoInternetToast(context)
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -41,6 +53,17 @@ class SearchFragment : Fragment() {
         setupListeners()
 
         viewModel.searchState.observe(viewLifecycleOwner) { state -> renderState(state) }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        internetReceiver.resetInitialState(requireContext())
+        registerInternetReceiver()
+    }
+
+    override fun onPause() {
+        unregisterInternetReceiver()
+        super.onPause()
     }
 
     override fun onDestroyView() {
@@ -175,7 +198,36 @@ class SearchFragment : Fragment() {
     }
 
     private fun hideKeyboard() {
-        val imm = requireActivity().getSystemService(android.content.Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        val imm = requireActivity().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
         imm.hideSoftInputFromWindow(binding.searchEditText.windowToken, 0)
+    }
+
+    private fun registerInternetReceiver() {
+        if (isInternetReceiverRegistered) return
+        ContextCompat.registerReceiver(
+            requireContext(),
+            internetReceiver,
+            IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION),
+            ContextCompat.RECEIVER_NOT_EXPORTED
+        )
+        isInternetReceiverRegistered = true
+    }
+
+    private fun unregisterInternetReceiver() {
+        if (!isInternetReceiverRegistered) return
+        try {
+            requireContext().unregisterReceiver(internetReceiver)
+        } catch (_: IllegalArgumentException) {
+        } finally {
+            isInternetReceiverRegistered = false
+        }
+    }
+
+    private fun showNoInternetToast(context: Context) {
+        Toast.makeText(
+            context,
+            context.getString(R.string.no_internet_connection),
+            Toast.LENGTH_SHORT
+        ).show()
     }
 }

--- a/app/src/main/java/com/practicum/playlistmaker/util/InternetConnectionReceiver.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/util/InternetConnectionReceiver.kt
@@ -1,0 +1,27 @@
+package com.practicum.playlistmaker.util
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+class InternetConnectionReceiver(
+    private val onConnectionLost: (Context) -> Unit
+) : BroadcastReceiver() {
+
+    private var lastConnected: Boolean? = null
+
+    fun resetInitialState(context: Context) {
+        lastConnected = NetworkUtils.isNetworkAvailable(context)
+    }
+
+    override fun onReceive(context: Context, intent: Intent?) {
+        val connected = NetworkUtils.isNetworkAvailable(context)
+        val previous = lastConnected
+
+        if (previous == true && !connected) {
+            onConnectionLost(context)
+        }
+
+        lastConnected = connected
+    }
+}

--- a/app/src/main/java/com/practicum/playlistmaker/util/NetworkUtils.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/util/NetworkUtils.kt
@@ -1,0 +1,20 @@
+package com.practicum.playlistmaker.util
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+
+object NetworkUtils {
+
+    fun isNetworkAvailable(context: Context): Boolean {
+        val connectivityManager =
+            context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+                ?: return false
+
+        val network = connectivityManager.activeNetwork ?: return false
+        val capabilities = connectivityManager.getNetworkCapabilities(network) ?: return false
+
+        return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
+            capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,4 +59,5 @@
     <string name="playlist_save_button">Сохранить</string>
     <string name="dialog_no">НЕТ</string>
     <string name="dialog_yes">ДА</string>
+    <string name="no_internet_connection">Отсутствует подключение к интернету</string>
 </resources>


### PR DESCRIPTION
- Добавлен показ Toast "Отсутствует подключение к интернету" при потере сети на экранах "Поиск" и "Аудиоплеер"

- Добавлены NetworkUtils/InternetConnectionReceiver

- PlaybackButtonView: убрана конвертация Drawable в Bitmap, отрисовка через Drawable.draw().

- Добавлен PlayerPlaybackService (bound + foreground) с логикой воспроизведения и уведомлением

- PlayerViewModel переведён на управление через PlayerServiceApi и StateFlow

- PlayerFragment теперь делает bind/unbind сервиса и передаёт события onStart/onStop для показа и скрытия уведомления

- Обновлён AndroidManifest.xml

- Добавлен запрос POST_NOTIFICATIONS